### PR TITLE
2021 Edition, Stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,18 @@
 [package]
 name = "autorun"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Vurv78 <Vurv78@users.noreply.github.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["dylib"]
-
-[profile.dev]
-debug = 0
+crate-type = ["cdylib"]
 
 [dependencies]
 rglua = { git = "https://github.com/Vurv78/rglua" }
 
-detour = "0.8.1"
+detour = { version = "0.8.1", default-features = false }
 
 # Global Mutable Variables
 once_cell = "1.8.0"
@@ -24,10 +21,18 @@ atomic = "0.5.0"
 # Misc
 home = "0.5.3"
 anyhow = "1.0.44"
+thiserror = "1.0.30"
 
 # Logging
-chrono = "0.4.19"
-log = "0.4.14"
-simplelog = "0.10.2"
+chrono = { version = "0.4.19", optional = true }
+log = { version = "0.4.14", optional = true }
+simplelog = { version = "0.11.0", optional = true }
 
 regex = "1.5.4"
+
+[features]
+default = ["runner"]
+runner = []
+
+# Disabled by default for now as this breaks autorun.
+logging = ["chrono", "log", "simplelog"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,15 @@
 name = "autorun"
 version = "0.5.1"
 authors = ["Vurv78 <Vurv78@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["dylib"]
+
+[profile.dev]
+debug = 0
 
 [dependencies]
 rglua = { git = "https://github.com/Vurv78/rglua" }
@@ -20,11 +23,11 @@ atomic = "0.5.0"
 
 # Misc
 home = "0.5.3"
-anyhow = "1.0.42"
+anyhow = "1.0.44"
 
 # Logging
 chrono = "0.4.19"
 log = "0.4.14"
-simplelog = "0.10.0"
+simplelog = "0.10.2"
 
 regex = "1.5.4"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ This file runs before every single lua script run on your client from addons and
 local script = sautorun.CODE
 if script:find("while true do end") then
 	sautorun.log("Found an evil script!")
-	return true -- Exit from here & don't run the script
+	-- Run our modified script that will replace all ``while true do end`` with ``while false do end``. 😎
+
+	return string.Replace(script, "while true do end", "while false do end")
+
+	-- OR: return true to not run the script at all.
 end
 ```
 __autorun.lua__  
@@ -73,10 +77,12 @@ sautorun.log( "Connected to server " .. sautorun.IP, DEBUG )
 ```
 
 ## Logging
-Autorun automatically writes logs to a log file whenever you boot up a game for your security and for easy debugging.  
-Check the sautorun-rs/logs directory for crash dumps & logs if you use something like [Safety](https://github.com/Vurv78/Safety) to log HTTP requests, etc.
+Autorun features logging under the ``logging`` feature. You need to build it yourself to enable this.  
+It will be re-enabled in the future when it is fixed.
+
+> Autorun automatically writes logs to a log file whenever you boot up a game for your security and for easy debugging.
+> Check the sautorun-rs/logs directory for crash dumps & logs if you use something like [Safety](https://github.com/Vurv78/Safety) to log HTTP requests, etc.
 
 ## Building
 1. [Setup Rust & Cargo](https://www.rust-lang.org/learn/get-started)
 2. Use ``build_win_32.bat`` or ``build_win_64.bat``.  
-**This requires Nightly** (in order to use ``thiscall`` and ``static_detour!``)  

--- a/build_win_32.bat
+++ b/build_win_32.bat
@@ -1,5 +1,12 @@
 @echo off
-rustup target add i686-pc-windows-msvc
-cargo build --target=i686-pc-windows-msvc
-move %cd%\target\i686-pc-windows-msvc\debug\Autorun.dll %cd%\gmsv_autorun_win32.dll
+set file_name=autorun.dll
+
+set target=i686-pc-windows-msvc
+set target_dir=%cd%\target\%target%\debug
+set out=%cd%\gmsv_autorun_win32.dll
+
+rustup target add %target%
+cargo build --target=%target%
+
+move %target_dir%\%file_name% %out%
 pause

--- a/build_win_32.bat
+++ b/build_win_32.bat
@@ -2,11 +2,11 @@
 set file_name=autorun.dll
 
 set target=i686-pc-windows-msvc
-set target_dir=%cd%\target\%target%\debug
+set target_dir=%cd%\target\%target%\release
 set out=%cd%\gmsv_autorun_win32.dll
 
 rustup target add %target%
-cargo build --target=%target%
+cargo build --release --target=%target%
 
 move %target_dir%\%file_name% %out%
 pause

--- a/build_win_64.bat
+++ b/build_win_64.bat
@@ -1,4 +1,12 @@
 @echo off
-cargo build
-move %cd%\target\debug\Autorun.dll %cd%\gmsv_autorun_win64.dll
+set file_name=autorun.dll
+
+set target=x86_64-pc-windows-msvc
+set target_dir=%cd%\target\%target%\debug
+set out=%cd%\gmsv_autorun_win64.dll
+
+rustup target add %target%
+cargo build --target=%target%
+
+move %target_dir%\%file_name% %out%
 pause

--- a/build_win_64.bat
+++ b/build_win_64.bat
@@ -2,11 +2,11 @@
 set file_name=autorun.dll
 
 set target=x86_64-pc-windows-msvc
-set target_dir=%cd%\target\%target%\debug
+set target_dir=%cd%\target\%target%\release
 set out=%cd%\gmsv_autorun_win64.dll
 
 rustup target add %target%
-cargo build --target=%target%
+cargo build --release --target=%target%
 
 move %target_dir%\%file_name% %out%
 pause

--- a/src/detours/lazy.rs
+++ b/src/detours/lazy.rs
@@ -1,0 +1,22 @@
+#[macro_export]
+macro_rules! lazy_detour {
+	// Lazy Path
+	( $vis:vis static $name:ident : $t:ty = ($target:expr, $tour:expr) ; $($rest:tt)* ) => {
+		$vis static $name: once_cell::sync::Lazy< detour::GenericDetour< $t > > = once_cell::sync::Lazy::new(|| unsafe {
+			match detour::GenericDetour::new( $target, $tour ) {
+				Ok(b) => {
+					b.enable().expect( concat!("Failed to enable detour '", stringify!($name), "'") );
+					b
+				},
+				Err(why) => panic!( concat!("Failed to create hook '", stringify!($name), "' {}"), why)
+			}
+		});
+		lazy_detour!( $($rest)* );
+	};
+	// OnceCell Path
+	( $vis:vis static $name:ident : $t:ty ; $($rest:tt)* ) => {
+		$vis static $name: once_cell::sync::OnceCell<detour::GenericDetour<$t>> = once_cell::sync::OnceCell::new();
+		lazy_detour!( $($rest)* );
+	};
+	() => ();
+}

--- a/src/detours/mod.rs
+++ b/src/detours/mod.rs
@@ -1,41 +1,49 @@
 use std::{fs, io::prelude::*, sync::atomic::Ordering};
 
 use crate::sys::{
-	util::{self, getAutorunHandle, getClientState, setClientState},
+	util::{getAutorunHandle, setClientState},
 	runlua::runLuaEnv, statics::*
 };
 
 use rglua::{
 	lua_shared::{self, *},
 	types::*,
-	rstring,
-	interface::IPanel
+	rstring
 };
-
-use detour::static_detour;
 
 const LUA_BOOL: i32 = rglua::globals::Lua::Type::Bool as i32;
 const LUA_STRING: i32 = rglua::globals::Lua::Type::String as i32;
 
-static_detour! {
-	pub static luaL_newstate_h: extern "C" fn() -> LuaState;
-	pub static luaL_loadbufferx_h: extern "C" fn(LuaState, *const i8, SizeT, *const i8, *const i8) -> CInt;
-	pub static joinserver_h: extern "C" fn(LuaState) -> CInt;
-	pub static paint_traverse_h: extern "thiscall" fn(&'static IPanel, usize, bool, bool);
+#[macro_use]
+pub mod lazy;
+
+// Make our own static detours because detours.rs is lame and locked theirs behind nightly. :)
+lazy_detour! {
+	pub static LUAL_NEWSTATE_H: extern "C" fn() -> LuaState = (*lua_shared::luaL_newstate, luaL_newstate);
+	pub static LUAL_LOADBUFFERX_H: extern "C" fn(LuaState, *const i8, SizeT, *const i8, *const i8) -> CInt = (*lua_shared::luaL_loadbufferx, luaL_loadbufferx);
+	pub static JOINSERVER_H: extern "C" fn(LuaState) -> CInt;
 }
 
-fn luaL_newstate() -> LuaState {
-	let state = luaL_newstate_h.call();
+#[cfg(feature = "runner")]
+use rglua::interface::IPanel;
+
+#[cfg(feature = "runner")]
+lazy_detour! {
+	static PAINT_TRAVERSE_H: extern "fastcall" fn(&'static IPanel, usize, bool, bool);
+}
+
+extern "C" fn luaL_newstate() -> LuaState {
+	let state = LUAL_NEWSTATE_H.call();
 	debug!("Got client state through luaL_newstate");
 	setClientState(state);
 	state
 }
 
-fn luaL_loadbufferx(state: LuaState, mut code: *const i8, mut size: SizeT, identifier: *const i8, mode: *const i8) -> CInt {
+extern "C" fn luaL_loadbufferx(state: LuaState, mut code: *const i8, mut size: SizeT, identifier: *const i8, mode: *const i8) -> CInt {
 	use crate::sys::util::initMenuState;
 	if MENU_STATE.get().is_none() {
 		if let Err(why) = initMenuState(state) {
-			error!("Couldn't initialize menu state.");
+			error!("Couldn't initialize menu state. {}", why);
 		}
 	}
 
@@ -54,7 +62,7 @@ fn luaL_loadbufferx(state: LuaState, mut code: *const i8, mut size: SizeT, ident
 				error!("{}", why);
 			}
 		} else {
-			error!( "Couldn't read your autorun script file at {}/{}", SAUTORUN_DIR.display(), AUTORUN_SCRIPT_PATH.display() );
+			error!( "Couldn't read your autorun script file at [{}]", AUTORUN_SCRIPT_PATH.display() );
 		}
 	}
 
@@ -90,25 +98,28 @@ fn luaL_loadbufferx(state: LuaState, mut code: *const i8, mut size: SizeT, ident
 
 	if do_run {
 		// Call the original function and return the value.
-		return luaL_loadbufferx_h.call( state, code, size, identifier, mode );
+		return LUAL_LOADBUFFERX_H.call( state, code, size, identifier, mode );
 	}
 	0
 }
 
 // Since the first lua state will always be the menu state, just keep a variable for whether joinserver has been hooked or not,
 // If not, then hook it.
-pub fn joinserver(state: LuaState) -> CInt {
-	let ip = rstring!( lua_tolstring(state, 1, 0) );
+pub extern "C" fn joinserver(state: LuaState) -> CInt {
+	let ip = rstring!(lua_tolstring(state, 1, 0));
 	info!("Joining Server with IP {}!", ip);
 
 	CURRENT_SERVER_IP.store(ip, Ordering::Relaxed); // Set the IP so we know where to write files in loadbufferx.
 	HAS_AUTORAN.store(false, Ordering::Relaxed);
 
-	joinserver_h.call(state)
+	JOINSERVER_H.get().unwrap().call(state)
 }
 
-fn paint_traverse(this: &'static IPanel, panel_id: usize, force_repaint: bool, force_allow: bool) {
-	paint_traverse_h.call(this, panel_id, force_repaint, force_allow);
+#[cfg(feature = "runner")]
+extern "fastcall" fn paint_traverse(this: &'static IPanel, panel_id: usize, force_repaint: bool, force_allow: bool) {
+	use crate::sys::util::{self, getClientState};
+
+	PAINT_TRAVERSE_H.get().unwrap().call(this, panel_id, force_repaint, force_allow);
 
 	let script_queue = &mut *LUA_SCRIPTS
 		.lock()
@@ -129,21 +140,14 @@ fn paint_traverse(this: &'static IPanel, panel_id: usize, force_repaint: bool, f
 				error!("{}", why);
 			},
 			Ok(_) => {
-				info!("Code [#{}] ran successfully.", script.len())
+				info!("Script of len #{} ran successfully.", script.len())
 			}
 		}
 	}
 }
 
-pub unsafe fn init() -> Result<(), detour::Error> {
-	luaL_loadbufferx_h
-		.initialize(*lua_shared::luaL_loadbufferx, luaL_loadbufferx)?
-		.enable()?;
-
-	luaL_newstate_h
-		.initialize(*lua_shared::luaL_newstate, luaL_newstate)?
-		.enable()?;
-
+#[cfg(feature = "runner")]
+unsafe fn init_paint_traverse() -> Result<(), detour::Error> {
 	use rglua::interface::*;
 
 	let vgui_interface = get_from_interface( "VGUI_Panel009", get_interface_handle("vgui2.dll").unwrap() )
@@ -151,7 +155,7 @@ pub unsafe fn init() -> Result<(), detour::Error> {
 
 	let panel_interface = vgui_interface.as_ref().unwrap();
 
-	type PaintTraverseFn = extern "thiscall" fn(&'static IPanel, usize, bool, bool);
+	type PaintTraverseFn = extern "fastcall" fn(&'static IPanel, usize, bool, bool);
 	// Get painttraverse raw function object to detour.
 	let painttraverse: PaintTraverseFn = std::mem::transmute(
 		(panel_interface.vtable as *mut *mut CVoid)
@@ -159,18 +163,33 @@ pub unsafe fn init() -> Result<(), detour::Error> {
 			.read()
 	);
 
-	paint_traverse_h
-		.initialize( painttraverse, paint_traverse )?
-		.enable()?;
+	let detour = detour::GenericDetour::new(painttraverse, paint_traverse)?;
+
+	PAINT_TRAVERSE_H.set(detour);
+	PAINT_TRAVERSE_H.get().unwrap().enable()?;
+
+	Ok(())
+}
+
+pub unsafe fn init() -> Result<(), detour::Error> {
+	use once_cell::sync::Lazy;
+
+	Lazy::force(&LUAL_LOADBUFFERX_H);
+	Lazy::force(&LUAL_NEWSTATE_H);
+
+	#[cfg(feature = "runner")]
+	init_paint_traverse()?;
 
 	Ok(())
 }
 
 pub unsafe fn cleanup() -> Result<(), detour::Error>{
-	luaL_loadbufferx_h.disable()?;
-	luaL_newstate_h.disable()?;
-	joinserver_h.disable()?;
-	paint_traverse_h.disable()?;
+	LUAL_LOADBUFFERX_H.disable()?;
+	LUAL_NEWSTATE_H.disable()?;
+	JOINSERVER_H.get().unwrap().disable()?;
+
+	#[cfg(feature = "runner")]
+	PAINT_TRAVERSE_H.get().unwrap().disable()?;
 
 	Ok(())
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,8 +9,6 @@ pub(crate) fn try_process_input() -> anyhow::Result<()> {
 	let (word, rest) = buffer.split_once(' ').unwrap_or( (buffer.trim_end(), "") );
 	let rest_trim = rest.trim_end();
 
-	debug!("Command used: [{}], rest [{}]", word, rest);
-
 	match word {
 		"lua_run_cl" => if let Err(why) = runLua(REALM_CLIENT, rest.to_owned()) {
 			error!("{}", why);

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,7 +6,7 @@ pub(crate) fn try_process_input() -> anyhow::Result<()> {
 	let mut buffer = String::new();
 
 	std::io::stdin().read_line(&mut buffer)?;
-	let (word, rest) = buffer.split_once(' ').unwrap_or( (&buffer.trim_end(), "") );
+	let (word, rest) = buffer.split_once(' ').unwrap_or( (buffer.trim_end(), "") );
 	let rest_trim = rest.trim_end();
 
 	debug!("Command used: [{}], rest [{}]", word, rest);
@@ -29,9 +29,8 @@ pub(crate) fn try_process_input() -> anyhow::Result<()> {
 
 		"lua_openscript_menu" => match std::fs::read_to_string( Path::new( rest ) ) {
 			Err(why) => error!("Errored on lua_openscript. [{}]", why),
-			Ok(contents) => match runLua( REALM_MENU, contents ) {
-				Err(why) => error!("Errored on lua_openscript. {}", why),
-				_ => ()
+			Ok(contents) => if let Err(why) = runLua( REALM_MENU, contents ) {
+				error!("Errored on lua_openscript. {}", why);
 			}
 		},
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ extern "system" {
 }
 
 fn init() {
-	if let Err(why) = logging::init_logging() {
+	if let Err(why) = logging::init() {
 		eprintln!("Couldn't start logging module. [{}]", why);
 		return;
 	}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,10 @@
-use simplelog::*;
-
-use chrono::prelude::*;
-use std::fs::File;
-use crate::sys::statics::SAUTORUN_LOG_DIR;
-
+#[cfg(feature = "logging")]
 pub fn init() -> anyhow::Result<()> {
+	use chrono::prelude::*;
+	use std::fs::File;
+	use crate::sys::statics::SAUTORUN_LOG_DIR;
+	use simplelog::*;
+
 	if !SAUTORUN_LOG_DIR.exists() {
 		std::fs::create_dir_all(&*SAUTORUN_LOG_DIR)?;
 	}
@@ -35,5 +35,53 @@ pub fn init() -> anyhow::Result<()> {
 		]
 	)?;
 
+	Ok(())
+}
+
+// Stderr
+#[cfg(not(feature = "logging"))]
+macro_rules! warn {
+	($($arg:tt)*) => {
+		eprintln!( $($arg)* )
+	};
+}
+
+// Will never print (unless logging is enabled)
+#[cfg(not(feature = "logging"))]
+macro_rules! trace {
+	($($arg:tt)*) => { () };
+}
+
+// Regular stdout
+#[cfg(not(feature = "logging"))]
+macro_rules! info {
+	($($arg:tt)*) => {
+		println!( $($arg)* )
+	};
+}
+
+// Only prints when in a debug build.
+#[cfg(all(not(feature = "logging"), debug_assertions))]
+macro_rules! debug {
+	($($arg:tt)*) => {
+		println!( $($arg)* )
+	};
+}
+
+// We are in a release build, don't print anything.
+#[cfg(all(not(feature = "logging"), not(debug_assertions)))]
+macro_rules! debug {
+	($($arg:tt)*) => { () };
+}
+
+// Print to stderr
+#[cfg(not(feature = "logging"))]
+macro_rules! error {
+	($($arg:tt)*) => {
+		eprintln!( $($arg)* )
+	};
+}
+
+pub fn init() -> anyhow::Result<()> {
 	Ok(())
 }

--- a/src/sys/runlua.rs
+++ b/src/sys/runlua.rs
@@ -39,7 +39,7 @@ pub fn runLua(realm: Realm, code: String) -> Result<(), &'static str>{
 
 extern "C" fn log(state: LuaState) -> i32 {
 	let s = luaL_checklstring(state, 1, 0);
-	let level = luaL_optinteger(state, 2, simplelog::Level::Info as isize);
+	let level = luaL_optinteger(state, 2, 3); // INFO by default
 
 	let str = rstring!(s);
 	match level {

--- a/src/sys/statics.rs
+++ b/src/sys/statics.rs
@@ -29,8 +29,9 @@ pub static CURRENT_SERVER_IP: Atomic<&'static str>                 = Atomic::new
 pub static HAS_AUTORAN: AtomicBool                                 = AtomicBool::new(false); // Whether an autorun script has been run and detected already.
 pub static MENU_STATE: OnceCell<AtomicPtr<CVoid>>                  = OnceCell::new();
 
+type LuaScript = Vec<(bool, String)>;
 // Scripts waiting to be ran in painttraverse
-pub static LUA_SCRIPTS: Lazy<Arc<Mutex<Vec< (bool, String) >>>> = Lazy::new(|| {
+pub static LUA_SCRIPTS: Lazy<Arc<Mutex<LuaScript>>> = Lazy::new(|| {
 	Arc::new( Mutex::new( Vec::new() ) )
 });
 

--- a/src/sys/statics.rs
+++ b/src/sys/statics.rs
@@ -9,6 +9,7 @@ use rglua::types::*;
 // ---------------- Configs ---------------- //
 pub static HOME_DIR: Lazy<PathBuf> = Lazy::new(|| home::home_dir().expect("Couldn't get your home directory!") );
 pub static SAUTORUN_DIR: Lazy<PathBuf> = Lazy::new(|| HOME_DIR.join("sautorun-rs") );
+#[cfg(feature = "logging")]
 pub static SAUTORUN_LOG_DIR: Lazy<PathBuf> = Lazy::new(|| SAUTORUN_DIR.join("logs") );
 pub static SAUTORUN_SCRIPT_DIR: Lazy<PathBuf> = Lazy::new(|| SAUTORUN_DIR.join("scripts") );
 

--- a/src/sys/util.rs
+++ b/src/sys/util.rs
@@ -115,7 +115,7 @@ const REPL: &str = "_";
 
 // Returns a string that is safe to use as a file path
 pub fn sanitizePath<T: AsRef<str>>(input: T) -> String  {
-	let path = ILLEGAL.replace_all(&input.as_ref(), REPL);
+	let path = ILLEGAL.replace_all(input.as_ref(), REPL);
 	let path = CONTROL_RESERVED.replace_all(&path, REPL);
 	let path = RESERVED.replace_all(&path, REPL);
 	let path = WINDOWS_RESERVED.replace_all(&path, REPL);


### PR DESCRIPTION
Fixes #17 
Fixes #16

By default the ``runner`` gate will be enabled allowing you to use the cli to lua_run_* / openscript etc.

However logging has been disabled by default to investigate the cause of the Illegal Instructions.

* Crate is a cdylib again which makes binary size much smaller.
* This runs on STABLE RUST, having replaced thiscall with fastcall (however this will most likely break x86.)
* Default build_win_* builds will be releases now. Manually call cargo for debug builds.