### PR TITLE
Fix Windows compile errors

### DIFF
--- a/autorun/Cargo.toml
+++ b/autorun/Cargo.toml
@@ -47,7 +47,7 @@ colored = "2"
 # Windows specific
 [target.'cfg(windows)'.dependencies]
 trayicon = "0.1.3"
-winapi = { version = "0.3" }
+winapi = { version = "0.3", features = ["wincontypes", "wincon", "processenv", "consoleapi"] }
 tinyget = { version = "1.0", features = ["https"], optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
When trying to compile on Windows, the following errors would prevent from doing so:
``
could not find `wincon` in `um`
``
``
could not find `wincontypes` in `um`
``
``
could not find `processenv` in `um`
``
``
could not find `consoleapi` in `um`
``
This PR fixes them.