### PR TITLE
check for empty strings in fixpath

### DIFF
--- a/autorun/src/hooks/dumper.rs
+++ b/autorun/src/hooks/dumper.rs
@@ -24,7 +24,9 @@ fn fix_path(str: &str) -> Option<String> {
 
 	let mut dots = 0;
 
-	if !str.is_empty() {
+	if str.is_empty() {
+		return Some("unknown".to_string())
+	}
 
 	for char in str.chars() {
 		match char {
@@ -54,10 +56,7 @@ fn fix_path(str: &str) -> Option<String> {
 				}
 			}
 		}
-	}
-	else {
-		buf.push_str("unknown")
-	}
+	
 	Some(buf)
 }
 

--- a/autorun/src/hooks/dumper.rs
+++ b/autorun/src/hooks/dumper.rs
@@ -23,6 +23,9 @@ fn fix_path(str: &str) -> Option<String> {
 	let mut buf = String::new();
 
 	let mut dots = 0;
+
+	if !str.is_empty() {
+
 	for char in str.chars() {
 		match char {
 			':' | '*' | '?' | '"' | '<' | '>' | '|' => {
@@ -48,10 +51,13 @@ fn fix_path(str: &str) -> Option<String> {
 			_ => {
 				dots = 0;
 				buf.push(char)
+				}
 			}
 		}
 	}
-
+	else {
+		buf.push_str("unknown")
+	}
 	Some(buf)
 }
 


### PR DESCRIPTION
functions such as RunString ie `RunString("print('D:')", "")`  when placed with a empty string as the source put the file in `%userprofile%\autorun\lua_dumps` with the name of the server ip instead of placing the file inside of  `%userprofile%\autorun\lua_dumps\<SERVERIP>`